### PR TITLE
README is out of date, thanks to codept 0.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-*This project is **not supported** for the time being. The right thing to do
-with it is to port it to [codept][codept]; however, I don't have the time to do
-this right now. You are welcome to take over and do this.*
+*This project is **not supported** for the time being. Similar behaviour may be
+possible using [codept][codept] [v0.10][codept-0.10]'s `-nested` feature.*
 
 [codept]: https://github.com/octachron/codept
+[codept-0.10]: https://github.com/Octachron/codept/blob/master/Changelog.md#version-010
 
 # Namespaces &nbsp; [![version 0.5.1][version]][releases] [![BSD license][license-img]][license] [![Travis status][travis-img]][travis]
 


### PR DESCRIPTION
Hi! I'm new to OCaml, so this may not be a useful note, but:

See <https://github.com/Octachron/codept/blob/master/README.md>,

> Nested module hierarchy is also fully supported by codept starting with version 0.10. In particular, when the -nested option is enabled, a file with path dir_1/…/dir_N/a.ml will be mapped to the module Dir_1. … . Dir_n. A instead of just A.

Thus, this note at the top of the README may no longer be necessary. `(=`